### PR TITLE
Get a single post (post detail page)

### DIFF
--- a/api/postData.js
+++ b/api/postData.js
@@ -3,3 +3,17 @@ import { clientCredentials } from '../utils/client';
 const endpoint = clientCredentials.databaseURL;
 
 console.warn(endpoint);
+
+const getSinglePost = (postId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${postId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+export default getSinglePost;

--- a/components/forms/PostForm.js
+++ b/components/forms/PostForm.js
@@ -1,7 +1,89 @@
+// import React, { useState } from 'react';
+// import { Form } from 'react-bootstrap';
+
+// const nullPost = {
+//   title: '',
+//   content: '',
+//   imageURL: '',
+// };
+
+// export default function PostForm({ postObj }) {
+//   const [formDate, setFormData] = useState(nullPost);
+
+//   const handleChange = (e) => {
+//     const { name, value } = e.target;
+//     setFormData((prevState) => ({
+//       ...prevState,
+//       [name]: value,
+//     }));
+//   };
+
+//   const handleSubmit = (e) => {
+//     e.preventDefault();
+//     if (postObj?.id) {
+//       console.warn('update');
+//     } else {
+
+//     }
+//   };
+
+//   return (
+//     <Form onSubmit={handleSubmit}>
+
+//       <Form.Group>
+//         <Form.Label> Title of Post</Form.Label>
+//         <Form.Control
+//           type="text"
+//           placeholder="Enter a title..."
+//           name="title"
+//           value={formData.title}
+//           onChange={handleChange}
+//           required
+//         />
+//       </Form.Group>
+
+//       <Form.Group>
+//         <Form.Label> Article Content</Form.Label>
+//         <Form.Control
+//           type="text"
+//           placeholder="What do you have to share..."
+//           name="content"
+//           value={formData.content}
+//           onChange={handleChange}
+//           required
+//         />
+//       </Form.Group>
+
+//       <Form.Group>
+//         <Form.Label> Image URL</Form.Label>
+//         <Form.Control
+//           type="text"
+//           placeholder="Image"
+//           name="imageURL"
+//           value={formData.imageURL}
+//           onChange={handleChange}
+//           required
+//         />
+//       </Form.Group>
+
+//       <label htmlFor="tags">Tags</label>
+//       <select id="tags" name="tags" multiple>
+//         {tags.map((tag) => (
+//           <option key={tag.id} value={tag.id}>
+//             {tag.label}
+//           </option>
+//         ))}
+//       </select>
+
+//     </Form>
+//   );
+// }
 import React from 'react';
 
 export default function PostForm() {
   return (
-    <div>PostForm</div>
+    <div>
+      <p>test</p>
+    </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.1.3",
+    "date-fns": "^4.0.0",
     "firebase": "^8.2.0",
     "next": "12.0.7",
     "prop-types": "^15.7.2",
@@ -27,6 +28,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
+    "autoprefixer": "^10.4.20",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-next": "11.1.2",
@@ -38,6 +40,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
-    "prettier": "^2.4.1"
+    "postcss": "^8.4.47",
+    "prettier": "^2.4.1",
+    "tailwindcss": "^3.4.11"
   }
 }

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,7 +1,69 @@
-import React from 'react';
+/* eslint-disable @next/next/no-img-element */
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { format } from 'date-fns';
+import getSinglePost from '../../api/postData';
 
 export default function PostDetails() {
+  const [post, setPost] = useState({});
+
+  // grab the postId from the path name
+  const router = useRouter();
+  const { id } = router.query;
+
+  const getAPost = () => {
+    getSinglePost(id).then(setPost);
+  };
+
+  useEffect(() => {
+    getAPost();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Function to format the date
+  const formatDate = (dateString) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    return format(date, 'MMMM d, yyyy');
+  };
+
+  console.warn(post);
   return (
-    <div>PostDetails</div>
+    <div>
+      <div>
+        <div>
+          <p>{post.title}</p>
+          <p>{post.category?.label}</p>
+        </div>
+        <div className="img-container">
+          <img src={post.imgURL} alt="post-img-url" />
+        </div>
+        <div className="text-container">
+          <div className="flex flex-row">
+            <div>
+              <img
+                src={post.author?.imageURL}
+                alt="author"
+                style={{
+                  width: '40px',
+                  height: '40px',
+                  borderRadius: '50%',
+                  objectFit: 'cover',
+                  marginRight: '15px',
+                }}
+              />
+              <p className="font-thin">By {post.author?.firstName} {post.author?.lastName}</p>
+            </div>
+            <p className="ml-4">{formatDate(post.publicationDate)}</p>
+          </div>
+          <div>
+            {post.tags?.map((t) => (
+              <p>#{t.label}</p>
+            ))}
+          </div>
+          <div><p>{post.content}</p></div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/pages/posts/new.js
+++ b/pages/posts/new.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PostForm from '../../components/forms/PostForm';
 
 export default function NewPost() {
   return (
-    <div>NewPost</div>
+    <PostForm />
   );
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,7 @@
 @import 'bootstrap/dist/css/bootstrap.css';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html,
 body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -3,7 +3,7 @@ import 'firebase/auth';
 import { clientCredentials } from './client';
 
 const checkUser = (uid) => new Promise((resolve, reject) => {
-  fetch(`${clientCredentials.databaseURL}/checkuser`, {
+  fetch(`${clientCredentials.databaseURL}/checkuser/${uid}`, {
     method: 'POST',
     body: JSON.stringify({
       uid,

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -13,7 +13,7 @@ const checkUser = (uid) => new Promise((resolve, reject) => {
       Accept: 'application/json',
     },
   })
-    .then((resp) => resolve(resp.json()))
+    .then((resp) => resolve(resp))
     .catch(reject);
 });
 


### PR DESCRIPTION
## Detailed Description
<!--- Explain **what** was changed and **why** -->
- Added the api request for getSinglePost
- Within posts/[id].js I added the jsx that contains all post properties. Not including the comments. 
- Added a formatDate function using date-fns, which is helpful for date manipulation and formatting. 
**- I had to take out the .json on the checkuser in order for it not to throw me an error when I logged in. ** 

## Related Issues
#5 

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1.  First run `npm i` again because I have added new dependencies (tailwind and date-fns)
2. When you log in you can just change your URL path to posts/1
3. You should see all the post detail info and I left in the console.warn(post) so you can see what is being returned.

## Motivation and Context
This is required so that users can view the post content and it's associated post when on this page. 

## Screenshots (if applicable)

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [x ] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation

## 💬 Additional Notes
Run `npm i` again