### PR TITLE
View and delete posts

### DIFF
--- a/api/postData.js
+++ b/api/postData.js
@@ -2,7 +2,17 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
-console.warn(endpoint);
+const getAllPosts = () => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
 
 const getSinglePost = (postId) => new Promise((resolve, reject) => {
   fetch(`${endpoint}/posts/${postId}`, {
@@ -16,4 +26,16 @@ const getSinglePost = (postId) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-export default getSinglePost;
+const deletePost = (postId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${postId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+export { getAllPosts, getSinglePost, deletePost };

--- a/api/postData.js
+++ b/api/postData.js
@@ -33,7 +33,6 @@ const deletePost = (postId) => new Promise((resolve, reject) => {
       'Content-Type': 'application/json',
     },
   })
-    .then((response) => response.json())
     .then((data) => resolve(data))
     .catch(reject);
 });

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -14,23 +14,19 @@ export default function NavBar() {
     <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
       <Container>
         <Link passHref href="/">
-          <Navbar.Brand>CHANGE ME</Navbar.Brand>
+          <Navbar.Brand>RARE</Navbar.Brand>
         </Link>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="me-auto">
-            {/* CLOSE NAVBAR ON LINK SELECTION: https://stackoverflow.com/questions/72813635/collapse-on-select-react-bootstrap-navbar-with-nextjs-not-working */}
             <Link passHref href="/">
               <Nav.Link>Home</Nav.Link>
             </Link>
-            <Link passHref href="/delete-me">
-              <Nav.Link>Delete Me</Nav.Link>
-            </Link>
-            <Button variant="danger" onClick={signOut}>
-              Sign Out
-            </Button>
           </Nav>
         </Navbar.Collapse>
+        <Button variant="danger" onClick={signOut}>
+          Sign Out
+        </Button>
       </Container>
     </Navbar>
   );

--- a/components/cards/PostCard.js
+++ b/components/cards/PostCard.js
@@ -1,7 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Card, Col } from 'react-bootstrap';
+import { deletePost } from '../../api/postData';
 
-export default function PostCard() {
+export default function PostCard({ post, onUpdate }) {
+  const deleteThisPost = () => {
+    if (window.confirm(`Delete ${post.title}?`)) {
+      deletePost(post.id).then(() => onUpdate());
+    }
+  };
+
   return (
-    <div>PostCard</div>
+    <Col xs={12} md={6}>
+      <Card className="my-3">
+        <Card.Img variant="top" src={post.imageURL} />
+        <Card.Body>
+          <Card.Title>{post.title}</Card.Title>
+          <Card.Text>{post.category.label}</Card.Text>
+          <Card.Text>{post.publicationDate}</Card.Text>
+          <Card.Text>{post.author.firstName} {post.author.lastName}</Card.Text>
+          <Card.Text>{post.content}</Card.Text>
+          <Button href={`/posts/${post.id}`} variant="primary" className="me-2">View</Button>
+          <Button href={`/posts/edit/${post.id}`} variant="secondary" className="me-2">Edit</Button>
+          <Button onClick={deleteThisPost} variant="danger">Delete</Button>
+        </Card.Body>
+      </Card>
+    </Col>
   );
 }
+
+PostCard.propTypes = {
+  post: PropTypes.shape({
+    id: PropTypes.number,
+    title: PropTypes.string,
+    category: PropTypes.object,
+    author: PropTypes.object,
+    content: PropTypes.string,
+    imageURL: PropTypes.string,
+    publicationDate: PropTypes.string,
+  }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,27 +1,30 @@
-import { Button } from 'react-bootstrap';
-import { signOut } from '../utils/auth';
-import { useAuth } from '../utils/context/authContext';
+import { useEffect, useState } from 'react';
+import { getAllPosts } from '../api/postData';
+import PostCard from '../components/cards/PostCard';
 
-function Home() {
-  const { user } = useAuth();
+export default function Home() {
+  const [posts, setPosts] = useState([]);
+
+  const getPosts = () => {
+    getAllPosts().then(setPosts);
+  };
+
+  useEffect(() => {
+    getPosts();
+  }, []);
+
   return (
-    <div
-      className="text-center d-flex flex-column justify-content-center align-content-center"
-      style={{
-        height: '90vh',
-        padding: '30px',
-        maxWidth: '400px',
-        margin: '0 auto',
-      }}
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '100vh',
+    }}
     >
-      <h1>Hello {user.fbUser.displayName}! </h1>
-      <p>Your Bio: {user.bio}</p>
-      <p>Click the button below to logout!</p>
-      <Button variant="danger" type="button" size="lg" className="copy-btn" onClick={signOut}>
-        Sign Out
-      </Button>
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} onUpdate={getPosts} />
+      ))}
     </div>
   );
 }
-
-export default Home;

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { format } from 'date-fns';
-import getSinglePost from '../../api/postData';
+import { getSinglePost } from '../../api/postData';
 
 export default function PostDetails() {
   const [post, setPost] = useState({});


### PR DESCRIPTION
## Detailed Description
- Added getAllPosts and deletePost API calls
- Created PostCard component
- Updated index.js to display PostCard components
- Removed "delete me" link from navbar

## Related Issues
- #11 
- #13 

## How to Test
- Go to home page to view post cards
- Click the delete button to delete a post

## Motivation and Context
This change is required so users can view and delete posts.

## Types of Changes
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation