### PR TITLE
Add/Remove Tags to/from Posts

### DIFF
--- a/api/postTagData.js
+++ b/api/postTagData.js
@@ -1,0 +1,29 @@
+import { clientCredentials } from '../utils/client';
+
+const endpoint = clientCredentials.databaseURL;
+
+const addPostTag = (postId, tagId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${postId}/add-tag/${tagId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((resp) => resp.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const removePostTag = (postId, tagId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${postId}/remove-tag/${tagId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((resp) => resp.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export { addPostTag, removePostTag };

--- a/api/tagData.js
+++ b/api/tagData.js
@@ -14,4 +14,17 @@ const getAllTags = () => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-export default getAllTags;
+const createTag = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/tags`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((resp) => resp.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export { getAllTags, createTag };

--- a/components/forms/PostForm.js
+++ b/components/forms/PostForm.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
+import CreatableSelect from 'react-select/creatable';
 import React, { useEffect, useState } from 'react';
 import { Button, Form } from 'react-bootstrap';
 import { useRouter } from 'next/router';
 import { createPost, updatePost } from '../../api/postData';
 import getAllCategories from '../../api/categoryData';
 import { useAuth } from '../../utils/context/authContext';
+import getAllTags from '../../api/tagData';
 
 const nullPost = {
   title: '',
@@ -16,6 +18,8 @@ const nullPost = {
 export default function PostForm({ postObj }) {
   const [formData, setFormData] = useState(nullPost);
   const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [selectedTags, setSelectedTags] = useState([]);
   const router = useRouter();
   const { user } = useAuth();
 
@@ -29,6 +33,10 @@ export default function PostForm({ postObj }) {
       ...prevState,
       [name]: value,
     }));
+  };
+
+  const handleTagChange = (selections) => {
+    setSelectedTags(selections);
   };
 
   const handleSubmit = (e) => {
@@ -49,8 +57,10 @@ export default function PostForm({ postObj }) {
 
   useEffect(() => {
     getCategories();
+    getAllTags().then(setTags);
     if (postObj?.id) {
       setFormData({ ...postObj, categoryId: postObj.category.id });
+      setSelectedTags(postObj.tags.map((tag) => ({ value: tag.id, label: tag.label })));
     }
   }, [postObj]);
 
@@ -116,6 +126,18 @@ export default function PostForm({ postObj }) {
           </Form.Select>
         </Form.Label>
       </Form.Group>
+
+      <CreatableSelect
+        instanceId="tagSelect"
+        aria-label="Tags"
+        name="tags"
+        className="mb-3"
+        value={selectedTags}
+        isMulti
+        onChange={handleTagChange}
+        options={tags.map((tag) => ({ value: tag.id, label: tag.label }))}
+      />
+
       <Button variant="primary" type="submit"> {postObj.id ? 'Update Post' : 'Create Post'}
       </Button>
     </Form>
@@ -132,6 +154,10 @@ PostForm.propTypes = {
     category: PropTypes.shape({
       id: PropTypes.number,
     }),
+    tags: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      label: PropTypes.string,
+    })),
   }),
 };
 

--- a/components/tables/TagTable.js
+++ b/components/tables/TagTable.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Table } from 'react-bootstrap';
-import getAllTags from '../../api/tagData';
+import { getAllTags } from '../../api/tagData';
 
 export default function TagTable() {
   const [tag, setTag] = useState([]);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-bootstrap": "^2.4.0",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-select": "^5.8.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -60,14 +60,14 @@ export default function PostDetails() {
           </div>
           <div>
             {post.tags?.map((t) => (
-              <p>#{t.label}</p>
+              <p key={t.id}>#{t.label}</p>
             ))}
           </div>
           <div><p>{post.content}</p></div>
         </div>
       </div>
       <div>
-        <CommentForm author={user.id} post={id} onUpdate={getAPost} />
+        <CommentForm author={user.id} post={Number(id)} onUpdate={getAPost} />
       </div>
       <div>
         {post.comments?.map((comment) => (


### PR DESCRIPTION
## Detailed Description
Tags can be added and removed from posts using multi-select component on postForm
Added calls createTag (tagData), addPostTag & removePostTag (postTagData)

Added key to tags element on PostDetails
Converted post property to number prior to passing id into the CommentForm (was reading as a string pulled from the router)

## Related Issues
- #9 
- #15 

## How to Test
1.  npm install to install Creatable
2. Go to edit or create post
3. Use multi-select to add tags (type to create new ones or select from dropdown)
4. Hit submit, new tags and posttags should be added in pgAdmin

## Motivation and Context
Users want to add tags to their posts

## Screenshots (if applicable)

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation

## 💬 Additional Notes
<!--- Add any other context, discussions, or considerations regarding this PR. -->
